### PR TITLE
Use url-parse instead of native url module

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const {URL} = require('url');
+const URL = require('url-parse');
 const reservedPaths = require('github-reserved-names/reserved-names.json');
 
 const patchDiffRegex = /[.](patch|diff)$/;
@@ -37,7 +37,7 @@ function shortenURL(href, currentUrl = 'https://github.com') {
 	const {
 		origin,
 		pathname,
-		search,
+		query: search,
 		hash
 	} = new URL(href);
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "url": "./browser-url"
   },
   "dependencies": {
-    "github-reserved-names": "^1.0.3"
+    "github-reserved-names": "^1.0.3",
+    "url-parse": "^1.2.0"
   }
 }


### PR DESCRIPTION
The native `url` module has a different interface in node 6 as compared to node 8(see https://stackoverflow.com/a/45615942). Which is why this module is incompatible with node 6:

```
λ node --version
v6.12.0

λ yarn test
yarn run v1.3.2
$ xo && ava

  index.js:26:1
  ‼  26:1  Function shortenURL has a complexity of 23.  complexity
  1 warning
  1 failed
  GitHub.com URLs

  E:\Projects\repos\shorten-repo-url\index.js:31
   30:
   31:   currentUrl = new URL(currentUrl);
   32:   const currentRepo = currentUrl.pathname.slice(1).split('/', 2).join('/');

  Error thrown in test:
  TypeError {
    message: 'URL is not a constructor',
  }

  shortenURL (index.js:31:15)
  Test.urlMatcherMacro (test.js:8:8)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

```

This PR uses the [`url-parse`](https://www.npmjs.com/package/url-parse) package instead which has a mostly similar interface to the native `url` module in node 8.